### PR TITLE
update alpine version and use caddy v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.22.2
 
 WORKDIR /root
 

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,18 +1,16 @@
-0.0.0.0:80 {
-  root /root/ui
-  timeouts none
-  gzip
-  log stdout
-  errors stdout
-}
+:80 {
+  root * /root/ui
+  file_server
 
-# 代理华相的 API
-0.0.0.0:80/v1 {
-  proxy /  127.0.0.1:8080/v1 {
-    transparent
-    websocket
+  encode gzip
+
+  log {
+    output stdout
+    format console
   }
-  gzip
-  log stdout
-  errors stdout
+
+  # 代理华相的 API：保持原有 /v1 前缀转发到 127.0.0.1:8080
+  handle /v1* {
+    reverse_proxy 127.0.0.1:8080
+  }
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-caddy -quic --conf /root/Caddyfile
+caddy run --config /root/Caddyfile


### PR DESCRIPTION
because of this issus:https://github.com/wise2c-devops/breeze/issues/130

Alpine3.9 only support caddy v1.x and caddy v1.x do not support Ubuntu v20 and above

Suggest update Docker base image to Alpine lastest version like 3.22.2, it use v2.10.0 Caddy